### PR TITLE
Fix plain text support

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -21,7 +21,7 @@ from SublimeLinter.lint import NodeLinter, util
 class Textlint(NodeLinter):
     """Provides an interface to textlint."""
 
-    syntax = ('markdown', 'text', 'Markdown GFM', 'MarkdownEditing', 'Markdown Extended', 'Markdown', 'MultiMarkdown')
+    syntax = ('markdown', 'text', 'plain text', 'Markdown GFM', 'MarkdownEditing', 'Markdown Extended', 'Markdown', 'MultiMarkdown')
     # npm_name = 'textlint'
     cmd = ('textlint', '--format', 'compact', '--stdin', '--stdin-filename', '__RELATIVE_TO_FOLDER__')
     executable = None


### PR DESCRIPTION
I found that your plug-in does not support linting "Plain Text" (`*.txt`) correctly.

I've made a small fix for that.
